### PR TITLE
Issue 1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+# Nothing.

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org'
 
-# Nothing.
+gem 'r18n-core'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,8 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,13 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    r18n-core (2.1.5)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  r18n-core
+
+BUNDLED WITH
+   1.14.6

--- a/README.md
+++ b/README.md
@@ -1,3 +1,20 @@
 # Simulation of eCommerce store
 
 Read Issue #1 to get started.
+
+## Usage
+
+Use the `ECommerce::Product` class to represent your products. Each product can
+have its price. The product can be formatted along with its price. Locale and
+price precision can be configured in the `lib/config.rb` file.
+
+A sample script is included. It can be run by `rake sample` task.
+
+### Example
+
+```ruby
+require_relative('lib/product')
+
+product = ECommerce::Product.new 'MacBook Pro', 49999.9
+puts product # MacBook Pro (49 999,90 Kč)
+```

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,14 @@
+task default: %w[test]
+
+task :print do
+  ruby
+end
+
+task :test do
+  ruby 'test/helper_test.rb'
+  ruby 'test/product_test.rb'
+end
+
+task :sample do
+  ruby 'bin/sample.rb'
+end

--- a/bin/sample.rb
+++ b/bin/sample.rb
@@ -1,0 +1,13 @@
+#!/usr/bin/env ruby
+
+require_relative '../lib/product'
+
+products = []
+products << ECommerce::Product.new('MacBook Pro', 55990.00)
+products << ECommerce::Product.new('iMac', 39990.00)
+products << ECommerce::Product.new('Mac Pro', 95990.00)
+
+puts 'Máme na skladě:'
+products.each do |product|
+  puts "• #{product}"
+end

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -1,5 +1,11 @@
+require 'r18n-core'
+
 module ECommerce
 
   PRICE_PRECISION = 2
+  CURRENCY        = 'Kč'
+  LOCALE          = :cs
 
 end
+
+R18n.set ECommerce::LOCALE

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -4,8 +4,6 @@ module ECommerce
 
   PRICE_PRECISION = 2
   CURRENCY        = 'Kč'
-  LOCALE          = :cs
+  LOCALE          = R18n::Locale::load :cs
 
 end
-
-R18n.set ECommerce::LOCALE

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -1,0 +1,5 @@
+module ECommerce
+
+  PRICE_PRECISION = 2
+
+end

--- a/lib/helper.rb
+++ b/lib/helper.rb
@@ -1,0 +1,27 @@
+require_relative 'config'
+
+module ECommerce
+
+  class Helper
+
+    class << self
+
+      def format_price price
+        rounded   = price.round PRICE_PRECISION
+        localized = LOCALE.localize(rounded)
+
+        separator = LOCALE.number_decimal
+        parts     = localized.split(separator)
+        if parts[1].length < PRICE_PRECISION
+          missing_zeroes = PRICE_PRECISION - parts[1].length
+          parts[1] += '0' * missing_zeroes
+        end
+
+        "#{parts.join(separator)} #{CURRENCY}"
+      end
+
+    end
+
+  end
+
+end

--- a/lib/product.rb
+++ b/lib/product.rb
@@ -5,8 +5,16 @@ module ECommerce
    attr_reader :name, :price
 
     def initialize name, price
-      @name  = name
-      @price = price
+      self.name  = name
+      self.price = price
+    end
+
+    def name= name
+      @name = name.to_s
+    end
+
+    def price= price
+      @price = price.to_f
     end
 
   end

--- a/lib/product.rb
+++ b/lib/product.rb
@@ -1,9 +1,12 @@
 require_relative 'config'
+
 module ECommerce
 
   class Product
 
-   attr_reader :name, :price
+    include R18n::Helpers
+
+    attr_reader :name, :price
 
     def initialize name, price
       self.name  = name
@@ -15,7 +18,12 @@ module ECommerce
     end
 
     def price= price
-      @price = price.to_f.round ECommerce::PRICE_PRECISION
+      @price = price.to_f.round PRICE_PRECISION
+    end
+
+    def to_s
+      price_formatted = l @price
+      "#{@name} (#{price_formatted} #{CURRENCY})"
     end
 
   end

--- a/lib/product.rb
+++ b/lib/product.rb
@@ -1,3 +1,4 @@
+require_relative 'config'
 module ECommerce
 
   class Product
@@ -14,7 +15,7 @@ module ECommerce
     end
 
     def price= price
-      @price = price.to_f
+      @price = price.to_f.round ECommerce::PRICE_PRECISION
     end
 
   end

--- a/lib/product.rb
+++ b/lib/product.rb
@@ -1,0 +1,14 @@
+module ECommerce
+
+  class Product
+
+   attr_reader :name, :price
+
+    def initialize name, price
+      @name  = name
+      @price = price
+    end
+
+  end
+
+end

--- a/lib/product.rb
+++ b/lib/product.rb
@@ -1,10 +1,9 @@
 require_relative 'config'
+require_relative 'helper'
 
 module ECommerce
 
   class Product
-
-    include R18n::Helpers
 
     attr_reader :name, :price
 
@@ -22,8 +21,7 @@ module ECommerce
     end
 
     def to_s
-      price_formatted = l @price
-      "#{@name} (#{price_formatted} #{CURRENCY})"
+      "#{@name} (#{Helper.format_price(@price)})"
     end
 
   end

--- a/test/helper_test.rb
+++ b/test/helper_test.rb
@@ -1,0 +1,30 @@
+require_relative '../lib/helper'
+require 'test/unit'
+
+class HelperTest < Test::Unit::TestCase
+
+  def test_price_is_localized
+    assert_equal '1 234,56 Kč', ECommerce::Helper.format_price(1234.56)
+  end
+
+  def test_currency_is_added
+    assert_equal '1,23 Kč', ECommerce::Helper.format_price(1.23)
+  end
+
+  def test_price_is_rounded
+    assert_equal '1,23 Kč', ECommerce::Helper.format_price(1.225)
+  end
+
+  def test_zeroes_are_added
+    assert_equal '1,20 Kč', ECommerce::Helper.format_price(1.2)
+  end
+
+  def test_zeroes_are_added_after_rounding
+    assert_equal '1,20 Kč', ECommerce::Helper.format_price(1.199)
+  end
+
+  def test_zeroes_are_added_for_integers
+    assert_equal '1,00 Kč', ECommerce::Helper.format_price(1)
+  end
+
+end

--- a/test/product_test.rb
+++ b/test/product_test.rb
@@ -19,7 +19,7 @@ class ProductTest < Test::Unit::TestCase
     assert_equal price, product.price
   end
 
-  # Test data type conversion.
+  # Test value conversion.
 
   def test_name_is_string
     product = ECommerce::Product.new({ line: 'MacBook', variety: 'Pro' },
@@ -30,6 +30,11 @@ class ProductTest < Test::Unit::TestCase
   def test_price_is_float
     product = ECommerce::Product.new 'MacBook Pro', 49999
     assert product.price.is_a? Float
+  end
+
+  def test_price_is_rounded
+    product = ECommerce::Product.new 'MacBook Pro', 49999.985
+    assert_equal 49999.99, product.price
   end
 
 end

--- a/test/product_test.rb
+++ b/test/product_test.rb
@@ -37,4 +37,11 @@ class ProductTest < Test::Unit::TestCase
     assert_equal 49999.99, product.price
   end
 
+  # Test output.
+
+  def test_product_is_printable
+    product = ECommerce::Product.new 'MacBook Pro', 49999.99
+    assert_equal 'MacBook Pro (49 999,99 Kč)', product.to_s
+  end
+
 end

--- a/test/product_test.rb
+++ b/test/product_test.rb
@@ -1,0 +1,22 @@
+require_relative '../lib/product'
+require 'test/unit'
+
+class ProductTest < Test::Unit::TestCase
+
+  # Start with a few rather useless tests just for the sake of having some.
+
+  def test_product_has_name
+    name = 'MacBook Pro'
+
+    product = ECommerce::Product.new name, 49999.99
+    assert_equal name, product.name
+  end
+
+  def test_product_has_price
+    price = 49999.99
+
+    product = ECommerce::Product.new 'MacBook Pro', price
+    assert_equal price, product.price
+  end
+
+end

--- a/test/product_test.rb
+++ b/test/product_test.rb
@@ -40,8 +40,8 @@ class ProductTest < Test::Unit::TestCase
   # Test output.
 
   def test_product_is_printable
-    product = ECommerce::Product.new 'MacBook Pro', 49999.99
-    assert_equal 'MacBook Pro (49 999,99 Kč)', product.to_s
+    product = ECommerce::Product.new 'MacBook Pro', 49999.90
+    assert_equal 'MacBook Pro (49 999,90 Kč)', product.to_s
   end
 
 end

--- a/test/product_test.rb
+++ b/test/product_test.rb
@@ -19,4 +19,17 @@ class ProductTest < Test::Unit::TestCase
     assert_equal price, product.price
   end
 
+  # Test data type conversion.
+
+  def test_name_is_string
+    product = ECommerce::Product.new({ line: 'MacBook', variety: 'Pro' },
+                                     49999.99)
+    assert product.name.is_a? String
+  end
+
+  def test_price_is_float
+    product = ECommerce::Product.new 'MacBook Pro', 49999
+    assert product.price.is_a? Float
+  end
+
 end


### PR DESCRIPTION
Vytvořil jsem modul `ECommerce` a v něm modelovou třídu `Product`. Obsahuje pouze název a cenu. Je možné ho převést na řetězec. Tím je splněna druhá podmínka: výskyt této třídy lze vypsat.

Aby to nebylo úplně tak holé, přidal jsem formátování ceny výrobku. Vypíše se tak vždy se dvěma desetinnými místy a měnou. K tomu slouží třída `Helper` a soubor s nastavením. O formátování se stará knihovna [ai/r18n](https://github.com/ai/r18n) uvedená v souboru _Gemfile_.

Zároveň je tak i co testovat. Použil jsem přímo přibalený framework _test-unit_. Proč zrovna ten? Zkušeností s testováním mám méně a tento už jsem aspoň někdy zkusil použít. Testy lze spustit zavoláním úlohy `rake test`, nebo jenom `rake`.

Popis použití s příkladem jsem přidal do _README_. Jednoduchý příkladový výpis produktů lze spustit úlohou `rake sample`.